### PR TITLE
Fixed CSS z-index for page header

### DIFF
--- a/src/components/template.js
+++ b/src/components/template.js
@@ -29,6 +29,7 @@ const Header = styled.div({
   top: 0,
   color: colors.text1,
   backgroundColor: 'white',
+  zIndex: 10,
   [breakpoints.md]: {
     display: 'flex'
   }

--- a/src/components/template.js
+++ b/src/components/template.js
@@ -29,7 +29,7 @@ const Header = styled.div({
   top: 0,
   color: colors.text1,
   backgroundColor: 'white',
-  zIndex: 10,
+  zIndex: 1,
   [breakpoints.md]: {
     display: 'flex'
   }


### PR DESCRIPTION
When the site is opened on a mobile device the headings would roll over the sticky page header.
Fixed it via adding a z-index 1.

In summary:
z-index: 1 is being used by page header.
z-index: 2 is being used by side bar.
z-index: 0 (implicitly) is being used by page content.

@ Maintainers: Please set any z-index more than 0 according to your frontend practices.

The following problem:
![principledgraphql com_(iPhone X)](https://user-images.githubusercontent.com/23742442/98572777-0495ae80-22dc-11eb-905b-a9fc46d2f8e4.png)

